### PR TITLE
FIX - hash changes for add invoice

### DIFF
--- a/src/engine-actions/create-invoice.js
+++ b/src/engine-actions/create-invoice.js
@@ -6,10 +6,11 @@ const { addInvoice } = require('../lnd-actions')
  * @param {String} memo
  * @param {Number} expiry - in seconds
  * @param {Number} value
+ * @returns {String} paymentRequest hash of invoice from lnd
  */
 async function createInvoice (memo, expiry, value) {
-  const { rHash } = await addInvoice(memo, expiry, value, { client: this.client })
-  return rHash
+  const { paymentRequest } = await addInvoice(memo, expiry, value, { client: this.client })
+  return paymentRequest
 }
 
 module.exports = createInvoice

--- a/src/engine-actions/create-invoice.spec.js
+++ b/src/engine-actions/create-invoice.spec.js
@@ -10,15 +10,15 @@ describe('createInvoice', () => {
   let addInvoiceStub
   let clientStub
   let invoiceResponse
-  let rHash
+  let paymentRequest
   let res
 
   beforeEach(() => {
     memo = 'MEMO'
     expiry = '2000'
     value = '100'
-    rHash = '1234'
-    invoiceResponse = { rHash }
+    paymentRequest = '1234'
+    invoiceResponse = { paymentRequest }
     addInvoiceStub = sinon.stub().returns(invoiceResponse)
     clientStub = sinon.stub()
 
@@ -34,7 +34,7 @@ describe('createInvoice', () => {
     expect(addInvoiceStub).to.have.been.calledWith(memo, expiry, value, sinon.match({ client: clientStub }))
   })
 
-  it('returns an rHash', () => {
-    expect(res).to.be.eql(rHash)
+  it('returns a paymentRequest hash', () => {
+    expect(res).to.be.eql(paymentRequest)
   })
 })


### PR DESCRIPTION
We need to return a `paymentRequest` hash from the `createInvoice` method to allow the relayer/broker to have the correct payment information.