### PR TITLE
FIX: wait for policy to be updated before returning a created channel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5898,6 +5898,11 @@
       "integrity": "sha512-fc1DDqbiyz5vxRO4xkiATwfWUw1FV7W20+FJYal1SnoIYgNuB4WNxYLtbG3zjUBwOSk3P4u1TgBAZYG/aqBWMw==",
       "dev": true
     },
+    "timeout-as-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-as-promise/-/timeout-as-promise-1.0.0.tgz",
+      "integrity": "sha1-c2foEfyZKs/Nzaq/LlDfr4shV28="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "big.js": "5.1.2",
-    "grpc": "1.11.3"
+    "grpc": "1.11.3",
+    "timeout-as-promise": "1.0.0"
   }
 }

--- a/src/engine-actions/create-channel.js
+++ b/src/engine-actions/create-channel.js
@@ -9,6 +9,7 @@ const {
 const {
   feeRateForSymbol
 } = require('../utils')
+const delay = require('timeout-as-promise')
 
 /**
  * Default timelock delta
@@ -120,11 +121,9 @@ async function createChannel (host, publicKey, fundingAmount, symbol) {
   // for the channel to open
   if (process.env.NODE_ENV === 'development') {
     this.logger.debug('Queuing channel to be updated in 2 minutes')
-
-    setTimeout(async () => {
-      this.logger.debug('Updating channel point', { chanPoint, feeRate })
-      await updateChannelPolicy(chanPoint, feeRate, TIMELOCK_DELTA, { client: this.client })
-    }, 120000)
+    await delay(120000)
+    this.logger.debug('Updating channel point', { chanPoint, feeRate })
+    await updateChannelPolicy(chanPoint, feeRate, TIMELOCK_DELTA, { client: this.client })
   }
 
   return true


### PR DESCRIPTION
For simulated channels, they are not really open until the policy is updated.

Many of the scripts that invoke this end up exiting or not informing the user that there is more time needed to complete the process.