### PR TITLE
FIX: use the current channel to determine time lock

### DIFF
--- a/src/engine-actions/execute-swap.js
+++ b/src/engine-actions/execute-swap.js
@@ -116,10 +116,11 @@ function routeFromPath (inboundAmount, blockHeight, finalCLTVDelta, path, counte
       // no additional timelock for an outgoing link since there is no outgoing link
       timeLockDelta = 0
     } else {
-      // this node's next channel is what determines the fee/timelock to transit the link
+      timeLockDelta = channel.policy.timeLockDelta + CLTV_BUFFER
+
+      // this node's next channel is what determines the fee to transit the link
       const nextChannel = backtrack[index - 1]
       feeMsat = computeFee(currentAmountMsat, nextChannel.policy)
-      timeLockDelta = nextChannel.policy.timeLockDelta + CLTV_BUFFER
     }
 
     // if we are at the counterparty we need to switch currency amounts, and there is no fee

--- a/src/engine-actions/execute-swap.spec.js
+++ b/src/engine-actions/execute-swap.spec.js
@@ -30,7 +30,7 @@ describe('execute-swap', () => {
           policy: {
             feeBaseMsat: '2000',
             feeRateMilliMsat: '7',
-            timeLockDelta: 10
+            timeLockDelta: 100
           }
         },
         {
@@ -41,7 +41,7 @@ describe('execute-swap', () => {
           policy: {
             feeBaseMsat: '1000',
             feeRateMilliMsat: '7',
-            timeLockDelta: 10
+            timeLockDelta: 100
           }
         },
         {
@@ -52,7 +52,7 @@ describe('execute-swap', () => {
           policy: {
             feeBaseMsat: '1000',
             feeRateMilliMsat: '6',
-            timeLockDelta: 10
+            timeLockDelta: 100
           }
         },
         {
@@ -63,7 +63,7 @@ describe('execute-swap', () => {
           policy: {
             feeBaseMsat: '1000',
             feeRateMilliMsat: '6',
-            timeLockDelta: 10
+            timeLockDelta: 100
           }
         }
       ]
@@ -72,7 +72,15 @@ describe('execute-swap', () => {
     it('calculates the total time lock', () => {
       const route = routeFromPath(inboundAmount, blockHeight, finalCLTVDelta, path, counterpartyPosition, outboundAmount)
 
-      expect(route).to.have.property('totalTimeLock', 5043)
+      expect(route).to.have.property('totalTimeLock', 5313)
+    })
+
+    it('calculates the total time lock for diverse policies', () => {
+      path[0].policy.timeLockDelta = 50
+
+      const route = routeFromPath(inboundAmount, blockHeight, finalCLTVDelta, path, counterpartyPosition, outboundAmount)
+
+      expect(route).to.have.property('totalTimeLock', 5263)
     })
 
     it('calculates the total fees', () => {
@@ -114,8 +122,18 @@ describe('execute-swap', () => {
     it('includes expiry in the hop', () => {
       const route = routeFromPath(inboundAmount, blockHeight, finalCLTVDelta, path, counterpartyPosition, outboundAmount)
 
-      expect(route.hops[0]).to.have.property('expiry', 5032)
-      expect(route.hops[1]).to.have.property('expiry', 5021)
+      expect(route.hops[0]).to.have.property('expiry', 5212)
+      expect(route.hops[1]).to.have.property('expiry', 5111)
+      expect(route.hops[2]).to.have.property('expiry', 5010)
+      expect(route.hops[3]).to.have.property('expiry', 5010)
+    })
+
+    it('includes expiry for diverse policies', () => {
+      path[1].policy.timeLockDelta = 50
+      const route = routeFromPath(inboundAmount, blockHeight, finalCLTVDelta, path, counterpartyPosition, outboundAmount)
+
+      expect(route.hops[0]).to.have.property('expiry', 5162)
+      expect(route.hops[1]).to.have.property('expiry', 5111)
       expect(route.hops[2]).to.have.property('expiry', 5010)
       expect(route.hops[3]).to.have.property('expiry', 5010)
     })
@@ -255,13 +273,13 @@ describe('execute-swap', () => {
             feeBaseMsat: '1000',
             feeRateMilliMsat: '7',
             minHtlc: '144',
-            timeLockDelta: 9
+            timeLockDelta: 90
           },
           node2Policy: {
             feeBaseMsat: '2000',
             feeRateMilliMsat: '7',
             minHtlc: '144',
-            timeLockDelta: 10
+            timeLockDelta: 100
           }
         },
         {
@@ -275,13 +293,13 @@ describe('execute-swap', () => {
             feeBaseMsat: '1000',
             feeRateMilliMsat: '7',
             minHtlc: '144',
-            timeLockDelta: 9
+            timeLockDelta: 90
           },
           node2Policy: {
             feeBaseMsat: '2000',
             feeRateMilliMsat: '7',
             minHtlc: '144',
-            timeLockDelta: 10
+            timeLockDelta: 100
           }
         }
       ]
@@ -315,7 +333,7 @@ describe('execute-swap', () => {
           feeBaseMsat: '1000',
           feeRateMilliMsat: '7',
           minHtlc: '144',
-          timeLockDelta: 9
+          timeLockDelta: 90
         }
       })
       expect(path[1]).to.be.eql({
@@ -327,7 +345,7 @@ describe('execute-swap', () => {
           feeBaseMsat: '1000',
           feeRateMilliMsat: '7',
           minHtlc: '144',
-          timeLockDelta: 9
+          timeLockDelta: 90
         }
       })
     })
@@ -367,13 +385,13 @@ describe('execute-swap', () => {
             feeBaseMsat: '1000',
             feeRateMilliMsat: '7',
             minHtlc: '144',
-            timeLockDelta: 9
+            timeLockDelta: 90
           },
           node2Policy: {
             feeBaseMsat: '2000',
             feeRateMilliMsat: '7',
             minHtlc: '144',
-            timeLockDelta: 10
+            timeLockDelta: 100
           }
         },
         {
@@ -387,13 +405,13 @@ describe('execute-swap', () => {
             feeBaseMsat: '1000',
             feeRateMilliMsat: '7',
             minHtlc: '144',
-            timeLockDelta: 9
+            timeLockDelta: 90
           },
           node2Policy: {
             feeBaseMsat: '2000',
             feeRateMilliMsat: '7',
             minHtlc: '144',
-            timeLockDelta: 10
+            timeLockDelta: 100
           }
         }
       ]


### PR DESCRIPTION
When time lock policies are diverse, the current route construction uses the next channel to determine required time lock, when it should be using the current channel since we don't apply the expiry until the next run through the loop.