### PR TITLE
FIX - Add `no-docker` argument to build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,20 @@ A current docker setup a functional BTC/LTC LND Engine:
 
 #### Installation (lnd-engine only)
 
-The following commands will install dependencies and import associated proto files for
-the lnd-engine codebase.
+The following commands will install dependencies, import associated proto files for
+the lnd-engine codebase and will build all docker images
 
 ```
 npm run build
 ```
 
-You can then use `npm run build-images` to build all docker containers.
+You can prevent the building of docker images with:
+
+```
+npm run build no-docker
+```
+
+Additionally, You can then use `npm run build-images` to build docker images separately.
 
 To run tests, use `npm run test`
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
+################################################
+# Build script for LND-engine
+#
+# Params:
+# - LND_PROTO_URL (optional)
+# - INCLUDE_DOCKER (optional, defaults to false)
+################################################
+
 set -e -u
+
+ARG=${1:-false}
 
 echo ""
 echo "It's time to BUILD! All resistance is futile."
@@ -10,8 +20,18 @@ npm i
 
 # Downloads an LND proto file from the sparkswap/lnd fork
 LND_PROTO_URL=${LND_PROTO_URL:-https://raw.githubusercontent.com/sparkswap/lnd/k%23epic/cross-chain-preimage/lnrpc/rpc.proto}
+
+rm -rf ./proto
+mkdir -p ./proto
+
 curl -o ./proto/lnd-rpc.proto $LND_PROTO_URL
 
 # Prepares the downloaded lnd-rpc proto file (installation steps tell you to remove this line)
 # (this is POSIX compliant as the versions of sed differ between OSes)
 sed 's|^import \"google/api/annotations.proto\";||' ./proto/lnd-rpc.proto > /tmp/file.$$ && mv /tmp/file.$$ ./proto/lnd-rpc.proto
+
+# If we want to build images with the command then we can use
+if [ "$ARG" != "no-docker" ]; then
+  echo "Building broker docker images"
+  npm run build-images
+fi


### PR DESCRIPTION
This PR changes the `npm run build` command to additionally build docker images. You can prevent docker-images from being built by using `npm run build no-docker`.