### PR TITLE
Feature/add pending channel balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ getUncommittedBalance
 getTotalChannelBalance
 getUnconfirmedBalance
 isBalanceSufficient
+getTotalPendingChannelBalance
 ```
 
 ### Channels

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ getTotalChannelBalance
 getUnconfirmedBalance
 isBalanceSufficient
 getTotalPendingChannelBalance
+getUncommittedPendingBalance
 ```
 
 ### Channels

--- a/src/engine-actions/get-total-channel-balance.js
+++ b/src/engine-actions/get-total-channel-balance.js
@@ -15,7 +15,7 @@ async function getTotalChannelBalance () {
   }
 
   const totalLocalBalance = channels.reduce((acc, c) => {
-    return acc.add(Big(c.localBalance))
+    return acc.plus(c.localBalance)
   }, Big(0))
 
   return totalLocalBalance.toString()

--- a/src/engine-actions/get-total-pending-channel-balance.js
+++ b/src/engine-actions/get-total-pending-channel-balance.js
@@ -1,0 +1,24 @@
+const { Big } = require('../utils')
+const { listPendingChannels } = require('../lnd-actions')
+
+/**
+ * Get local balance of all pending channels for a specific daemon
+ *
+ * @return {String} totalBalance (int64)
+ */
+async function getTotalPendingChannelBalance () {
+  const { pendingOpenChannels = [] } = await listPendingChannels({ client: this.client })
+
+  if (pendingOpenChannels.length === 0) {
+    this.logger.debug('getTotalChannelBalance: No channels exist')
+    return Big(0).toString()
+  }
+
+  const totalPendingLocalBalance = pendingOpenChannels.reduce((acc, c) => {
+    return acc.add(Big(c.channel.localBalance))
+  }, Big(0))
+
+  return totalPendingLocalBalance.toString()
+}
+
+module.exports = getTotalPendingChannelBalance

--- a/src/engine-actions/get-total-pending-channel-balance.js
+++ b/src/engine-actions/get-total-pending-channel-balance.js
@@ -15,7 +15,7 @@ async function getTotalPendingChannelBalance () {
   }
 
   const totalPendingLocalBalance = pendingOpenChannels.reduce((acc, c) => {
-    return acc.add(Big(c.channel.localBalance))
+    return acc.plus(c.channel.localBalance)
   }, Big(0))
 
   return totalPendingLocalBalance.toString()

--- a/src/engine-actions/get-total-pending-channel-balance.spec.js
+++ b/src/engine-actions/get-total-pending-channel-balance.spec.js
@@ -1,0 +1,35 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const getTotalPendingChannelBalance = rewire(path.resolve(__dirname, 'get-total-pending-channel-balance'))
+
+describe('getTotalPendingChannelBalance', () => {
+  let pendingOpenChannels
+  let listPendingChannelsStub
+  let logger
+
+  beforeEach(() => {
+    pendingOpenChannels = [
+      { channel: { localBalance: '10' } },
+      { channel: { localBalance: '1000' } }
+    ]
+
+    logger = {
+      debug: sinon.stub()
+    }
+
+    getTotalPendingChannelBalance.__set__('logger', logger)
+  })
+
+  it('returns 0 if no channels exist', async () => {
+    listPendingChannelsStub = sinon.stub().returns({})
+    getTotalPendingChannelBalance.__set__('listPendingChannels', listPendingChannelsStub)
+    return expect(await getTotalPendingChannelBalance()).to.be.eql('0')
+  })
+
+  it('returns the total balance of all channels on a daemon', async () => {
+    listPendingChannelsStub = sinon.stub().returns({ pendingOpenChannels })
+    getTotalPendingChannelBalance.__set__('listPendingChannels', listPendingChannelsStub)
+    return expect(await getTotalPendingChannelBalance()).to.be.eql('1010')
+  })
+})

--- a/src/engine-actions/get-uncommitted-balance.js
+++ b/src/engine-actions/get-uncommitted-balance.js
@@ -5,8 +5,8 @@ const { walletBalance } = require('../lnd-actions')
  * @returns {String} total
  */
 async function getUncommittedBalance () {
-  const { totalBalance } = await walletBalance({ client: this.client })
-  return totalBalance
+  const { confirmedBalance } = await walletBalance({ client: this.client })
+  return confirmedBalance
 }
 
 module.exports = getUncommittedBalance

--- a/src/engine-actions/get-uncommitted-balance.spec.js
+++ b/src/engine-actions/get-uncommitted-balance.spec.js
@@ -7,12 +7,12 @@ describe('getUncommittedBalance', () => {
   let walletBalanceStub
   let clientStub
   let balanceResponse
-  let totalBalance
+  let confirmedBalance
   let res
 
   beforeEach(() => {
-    totalBalance = '1234'
-    balanceResponse = { totalBalance }
+    confirmedBalance = '1234'
+    balanceResponse = { confirmedBalance }
     walletBalanceStub = sinon.stub().returns(balanceResponse)
     clientStub = sinon.stub()
 
@@ -29,6 +29,6 @@ describe('getUncommittedBalance', () => {
   })
 
   it('returns the totalBalance', () => {
-    expect(res).to.be.eql(totalBalance)
+    expect(res).to.be.eql(confirmedBalance)
   })
 })

--- a/src/engine-actions/get-uncommitted-pending-balance.js
+++ b/src/engine-actions/get-uncommitted-pending-balance.js
@@ -14,7 +14,7 @@ async function getUncommittedPendingBalance () {
     return Big(unconfirmedBalance).toString()
   }
 
-  const allPendingChannels = pendingClosingChannels + pendingForceClosingChannels + waitingCloseChannels
+  const allPendingChannels = pendingClosingChannels.concat(pendingForceClosingChannels).concat(waitingCloseChannels)
   const totalPendingLocalBalance = allPendingChannels.reduce((acc, c) => {
     return acc.add(Big(c.channel.localBalance))
   }, Big(0))

--- a/src/engine-actions/get-uncommitted-pending-balance.js
+++ b/src/engine-actions/get-uncommitted-pending-balance.js
@@ -1,0 +1,25 @@
+const { walletBalance, listPendingChannels } = require('../lnd-actions')
+const { Big } = require('../utils')
+
+/**
+ * Total balance of unspent funds
+ * @returns {String} total
+ */
+async function getUncommittedPendingBalance () {
+  const { unconfirmedBalance } = await walletBalance({ client: this.client })
+  const { pendingClosingChannels = [], pendingForceClosingChannels = [], waitingCloseChannels = [] } = await listPendingChannels({ client: this.client })
+
+  if (pendingClosingChannels.length === 0 && pendingForceClosingChannels.length === 0 && waitingCloseChannels.length === 0) {
+    this.logger.debug('getUncommittedPendingBalance: No channels exist')
+    return Big(unconfirmedBalance).toString()
+  }
+
+  const allPendingChannels = pendingClosingChannels + pendingForceClosingChannels + waitingCloseChannels
+  const totalPendingLocalBalance = allPendingChannels.reduce((acc, c) => {
+    return acc.add(Big(c.channel.localBalance))
+  }, Big(0))
+
+  return Big(unconfirmedBalance).add(totalPendingLocalBalance).toString()
+}
+
+module.exports = getUncommittedPendingBalance

--- a/src/engine-actions/get-uncommitted-pending-balance.js
+++ b/src/engine-actions/get-uncommitted-pending-balance.js
@@ -16,7 +16,7 @@ async function getUncommittedPendingBalance () {
 
   const allPendingChannels = pendingClosingChannels.concat(pendingForceClosingChannels).concat(waitingCloseChannels)
   const totalPendingLocalBalance = allPendingChannels.reduce((acc, c) => {
-    return acc.add(Big(c.channel.localBalance))
+    return acc.plus(c.channel.localBalance)
   }, Big(0))
 
   return Big(unconfirmedBalance).add(totalPendingLocalBalance).toString()

--- a/src/engine-actions/get-uncommitted-pending-balance.spec.js
+++ b/src/engine-actions/get-uncommitted-pending-balance.spec.js
@@ -32,13 +32,32 @@ describe('getUncommittedPendingBalance', () => {
     getUncommittedPendingBalance.__set__('logger', logger)
   })
 
-  it('returns 0 if no channels exist', async () => {
-    listPendingChannelsStub = sinon.stub().returns({})
+  it('returns 0 if no unconfirmed balance and no channels exist', async () => {
+    listPendingChannelsStub.resolves({})
+    walletBalanceStub.resolves({unconfirmedBalance: '0'})
+    getUncommittedPendingBalance.__set__('listPendingChannels', listPendingChannelsStub)
+    return expect(await getUncommittedPendingBalance()).to.be.eql('0')
+  })
+
+  it('returns the unconfirmed balance if no channels exist', async () => {
+    listPendingChannelsStub = sinon.stub().resolves({})
     getUncommittedPendingBalance.__set__('listPendingChannels', listPendingChannelsStub)
     return expect(await getUncommittedPendingBalance()).to.be.eql('1234')
   })
 
-  it('returns the total pending close channel balance combined with unconfirmed wallet balance', async () => {
+  it('adds pendingClosingChannels to the unconfirmed balance if the pendingClosingChannels exist', async () => {
+    listPendingChannelsStub.resolves({pendingClosingChannels})
+    getUncommittedPendingBalance.__set__('listPendingChannels', listPendingChannelsStub)
+    return expect(await getUncommittedPendingBalance()).to.be.eql('2244')
+  })
+
+  it('adds pendingClosingChannels and pendingForceClosingChannels to the unconfirmed balance if the channels exist', async () => {
+    listPendingChannelsStub.resolves({pendingClosingChannels, pendingForceClosingChannels})
+    getUncommittedPendingBalance.__set__('listPendingChannels', listPendingChannelsStub)
+    return expect(await getUncommittedPendingBalance()).to.be.eql('2274')
+  })
+
+  it('adds pendingClosingChannels, pendingForceClosingChannels,and waitingCloseChannels to the unconfirmed balance if the channels exist', async () => {
     getUncommittedPendingBalance.__set__('listPendingChannels', listPendingChannelsStub)
     return expect(await getUncommittedPendingBalance()).to.be.eql('2274')
   })

--- a/src/engine-actions/get-uncommitted-pending-balance.spec.js
+++ b/src/engine-actions/get-uncommitted-pending-balance.spec.js
@@ -1,0 +1,45 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const getUncommittedPendingBalance = rewire(path.resolve(__dirname, 'get-uncommitted-pending-balance'))
+
+describe('getUncommittedPendingBalance', () => {
+  let listPendingChannelsStub
+  let logger
+  let pendingClosingChannels
+  let pendingForceClosingChannels
+  let waitingCloseChannels
+  let unconfirmedBalance
+  let balanceResponse
+  let walletBalanceStub
+
+  beforeEach(() => {
+    pendingClosingChannels = [
+      { channel: { localBalance: '10' } },
+      { channel: { localBalance: '1000' } }
+    ]
+    pendingForceClosingChannels = [{ channel: { localBalance: '30' } }]
+    waitingCloseChannels = []
+
+    logger = {
+      debug: sinon.stub()
+    }
+    unconfirmedBalance = '1234'
+    balanceResponse = { unconfirmedBalance }
+    walletBalanceStub = sinon.stub().returns(balanceResponse)
+    listPendingChannelsStub = sinon.stub().resolves({pendingClosingChannels, pendingForceClosingChannels, waitingCloseChannels})
+    getUncommittedPendingBalance.__set__('walletBalance', walletBalanceStub)
+    getUncommittedPendingBalance.__set__('logger', logger)
+  })
+
+  it('returns 0 if no channels exist', async () => {
+    listPendingChannelsStub = sinon.stub().returns({})
+    getUncommittedPendingBalance.__set__('listPendingChannels', listPendingChannelsStub)
+    return expect(await getUncommittedPendingBalance()).to.be.eql('1234')
+  })
+
+  it('returns the total pending close channel balance combined with unconfirmed wallet balance', async () => {
+    getUncommittedPendingBalance.__set__('listPendingChannels', listPendingChannelsStub)
+    return expect(await getUncommittedPendingBalance()).to.be.eql('2274')
+  })
+})

--- a/src/engine-actions/index.js
+++ b/src/engine-actions/index.js
@@ -22,6 +22,7 @@ const translateSwap = require('./translate-swap')
 const getSettledSwapPreimage = require('./get-settled-swap-preimage')
 const numChannelsForAddress = require('./num-channels-for-address')
 const getTotalPendingChannelBalance = require('./get-total-pending-channel-balance')
+const getUncommittedPendingBalance = require('./get-uncommitted-pending-balance')
 
 module.exports = {
   getInvoices,
@@ -47,5 +48,6 @@ module.exports = {
   translateSwap,
   getSettledSwapPreimage,
   numChannelsForAddress,
-  getTotalPendingChannelBalance
+  getTotalPendingChannelBalance,
+  getUncommittedPendingBalance
 }

--- a/src/engine-actions/index.js
+++ b/src/engine-actions/index.js
@@ -21,6 +21,7 @@ const getPaymentChannelNetworkAddress = require('./get-payment-channel-network-a
 const translateSwap = require('./translate-swap')
 const getSettledSwapPreimage = require('./get-settled-swap-preimage')
 const numChannelsForAddress = require('./num-channels-for-address')
+const getTotalPendingChannelBalance = require('./get-total-pending-channel-balance')
 
 module.exports = {
   getInvoices,
@@ -45,5 +46,6 @@ module.exports = {
   getPaymentChannelNetworkAddress,
   translateSwap,
   getSettledSwapPreimage,
-  numChannelsForAddress
+  numChannelsForAddress,
+  getTotalPendingChannelBalance
 }


### PR DESCRIPTION
The wallet balance command on the broker needs pending balances because in the process of commit a balance to a channel or closing a channel, the funds go into a pending state. Without this change, the funds completely disappear and this is confusing and worrisome for the end user. 

1) Fix uncommitted balance to be the correct value from the LND api
2) Add a pending channel balance which is the amount of funds in the process of being committed.
3) Add a pending uncommitted channel balance which is the amount of funds in channels that are being closed combined with the amount of unconfirmed funds in the wallet. 