### PR TITLE
FIX - Increase BLOCK_BUFFER cltv value

### DIFF
--- a/src/engine-actions/execute-swap.js
+++ b/src/engine-actions/execute-swap.js
@@ -48,7 +48,7 @@ async function executeSwap (makerAddress, swapHash, amount) {
   // the maker (who is translating between chains) additional timelock. As the Taker,
   // we would prefer to add additional time (in blocks) to our finalCltvDelta than to
   // have to hltc be rejected.
-  const finalCltvDelta = Math.ceil(totalTimeLockInSeconds / secondsPerBlock) + BLOCK_BUFFER
+  const finalCltvDelta = Math.ceil((totalTimeLockInSeconds + BLOCK_BUFFER) / secondsPerBlock)
 
   const request = {
     destString: counterpartyPubKey,

--- a/src/engine-actions/execute-swap.spec.js
+++ b/src/engine-actions/execute-swap.spec.js
@@ -78,7 +78,7 @@ describe('executeSwap', () => {
   it('uses a final CLTV delta made up of the Maker\'s forwarding amount, the Relayer\'s forwarding amount, the Taker\'s final amount, and a buffer block', async () => {
     await executeSwap.call(engine, makerAddress, swapHash, amount)
 
-    expect(sendPayment).to.have.been.calledWith(sinon.match({ finalCltvDelta: 433 }))
+    expect(sendPayment).to.have.been.calledWith(sinon.match({ finalCltvDelta: 435 }))
   })
 
   it('throws on payment error', () => {

--- a/src/utils/cltv-delta.js
+++ b/src/utils/cltv-delta.js
@@ -31,14 +31,14 @@ const DEFAULT_RELAYER_FWD_DELTA = 86400
 const DEFAULT_MIN_FINAL_DELTA = 86400
 
 /**
- * The number of blocks to buffer any output timelock by to account for block ticks during a swap
- * This is especially problematic on simnet where we mine blocks every 10 seconds, but it is a known issue on mainnet
+ * The amount of time, in seconds, that we'd like to buffer any output timelock by to account for block ticks during a swap
+ * This is especially problematic on simnet where we mine blocks every 10 seconds and is a known issue on mainnet.
  *
  * @see {@link https://github.com/lightningnetwork/lnd/issues/535}
  * @type {Number}
  * @constant
  */
-const BLOCK_BUFFER = 1
+const BLOCK_BUFFER = 1800
 
 module.exports = {
   DEFAULT_MAKER_FWD_DELTA,


### PR DESCRIPTION
This PR converts BLOCK_BUFFER to seconds and increases the buffer that we use during finalCltv calculation