### PR TITLE
Feature/trading capacities

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ getUnconfirmedBalance
 isBalanceSufficient
 getTotalPendingChannelBalance
 getUncommittedPendingBalance
+getPendingChannelCapacities
+getOpenChannelCapacities
 ```
 
 ### Channels

--- a/src/engine-actions/get-open-channel-capacities.js
+++ b/src/engine-actions/get-open-channel-capacities.js
@@ -10,7 +10,7 @@ async function getOpenChannelCapacities () {
   const { channels = [] } = await listChannels({ client: this.client })
 
   if (channels.length === 0) {
-    this.logger.debug('getTotalChannelBalance: No channels exist')
+    this.logger.debug('getOpenChannelCapacities: No channels exist')
   }
 
   const activeLocalBalance = channels.filter((chan) => chan.active === true).reduce((acc, c) => {

--- a/src/engine-actions/get-open-channel-capacities.js
+++ b/src/engine-actions/get-open-channel-capacities.js
@@ -1,0 +1,40 @@
+const { Big } = require('../utils')
+const { listChannels } = require('../lnd-actions')
+
+/**
+ * Get local balance of all channels for a specific daemon
+ *
+ * @return {String} totalBalance (int64)
+ */
+async function getOpenChannelCapacities () {
+  const { channels = [] } = await listChannels({ client: this.client })
+
+  if (channels.length === 0) {
+    this.logger.debug('getTotalChannelBalance: No channels exist')
+    return Big(0).toString()
+  }
+
+  const activeLocalBalance = channels.filter((chan) => chan.active === true).reduce((acc, c) => {
+    return acc.plus(c.localBalance)
+  }, Big(0))
+
+  const activeRemoteBalance = channels.filter((chan) => chan.active === true).reduce((acc, c) => {
+    return acc.plus(c.remoteBalance)
+  }, Big(0))
+
+  const activeBalances = {localBalance: activeLocalBalance, remoteBalance: activeRemoteBalance}
+
+  const inactiveLocalBalance = channels.filter((chan) => chan.active === false).reduce((acc, c) => {
+    return acc.plus(c.localBalance)
+  }, Big(0))
+
+  const inactiveRemoteBalance = channels.filter((chan) => chan.active === false).reduce((acc, c) => {
+    return acc.plus(c.remoteBalance)
+  }, Big(0))
+
+  const inactiveBalances = {localBalance: inactiveLocalBalance, remoteBalance: inactiveRemoteBalance}
+
+  return { active: activeBalances, inactive: inactiveBalances }
+}
+
+module.exports = getOpenChannelCapacities

--- a/src/engine-actions/get-open-channel-capacities.js
+++ b/src/engine-actions/get-open-channel-capacities.js
@@ -11,7 +11,6 @@ async function getOpenChannelCapacities () {
 
   if (channels.length === 0) {
     this.logger.debug('getTotalChannelBalance: No channels exist')
-    return Big(0).toString()
   }
 
   const activeLocalBalance = channels.filter((chan) => chan.active === true).reduce((acc, c) => {
@@ -22,7 +21,7 @@ async function getOpenChannelCapacities () {
     return acc.plus(c.remoteBalance)
   }, Big(0))
 
-  const activeBalances = {localBalance: activeLocalBalance, remoteBalance: activeRemoteBalance}
+  const activeBalances = {localBalance: activeLocalBalance.toString(), remoteBalance: activeRemoteBalance.toString()}
 
   const inactiveLocalBalance = channels.filter((chan) => chan.active === false).reduce((acc, c) => {
     return acc.plus(c.localBalance)
@@ -32,7 +31,7 @@ async function getOpenChannelCapacities () {
     return acc.plus(c.remoteBalance)
   }, Big(0))
 
-  const inactiveBalances = {localBalance: inactiveLocalBalance, remoteBalance: inactiveRemoteBalance}
+  const inactiveBalances = {localBalance: inactiveLocalBalance.toString(), remoteBalance: inactiveRemoteBalance.toString()}
 
   return { active: activeBalances, inactive: inactiveBalances }
 }

--- a/src/engine-actions/get-open-channel-capacities.spec.js
+++ b/src/engine-actions/get-open-channel-capacities.spec.js
@@ -1,0 +1,39 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const getOpenChannelCapacities = rewire(path.resolve(__dirname, 'get-open-channel-capacities'))
+
+describe('getOpenChannelCapacities', () => {
+  let channels
+  let listChannelsStub
+  let logger
+
+  beforeEach(() => {
+    channels = [
+      { localBalance: '10', remoteBalance: '300', active: true },
+      { localBalance: '0', remoteBalance: '100', active: true },
+      { localBalance: '20', remoteBalance: '1000', active: false },
+      { localBalance: '10', remoteBalance: '15', active: true }
+    ]
+
+    logger = {
+      debug: sinon.stub()
+    }
+
+    getOpenChannelCapacities.__set__('logger', logger)
+  })
+
+  it('returns 0 for active and inactive if no channels exist', async () => {
+    const expectedRes = { active: { localBalance: '0', remoteBalance: '0' }, inactive: { localBalance: '0', remoteBalance: '0' } }
+    listChannelsStub = sinon.stub().returns({})
+    getOpenChannelCapacities.__set__('listChannels', listChannelsStub)
+    return expect(await getOpenChannelCapacities()).to.eql(expectedRes)
+  })
+
+  it('returns the total balance of all channels on a daemon', async () => {
+    const expectedRes = { active: { localBalance: '20', remoteBalance: '415' }, inactive: { localBalance: '20', remoteBalance: '1000' } }
+    listChannelsStub = sinon.stub().returns({ channels })
+    getOpenChannelCapacities.__set__('listChannels', listChannelsStub)
+    return expect(await getOpenChannelCapacities()).to.eql(expectedRes)
+  })
+})

--- a/src/engine-actions/get-pending-channel-capacities.js
+++ b/src/engine-actions/get-pending-channel-capacities.js
@@ -1,0 +1,28 @@
+const { Big } = require('../utils')
+const { listPendingChannels } = require('../lnd-actions')
+
+/**
+ * Get local balance of all channels for a specific daemon
+ *
+ * @return {String} totalBalance (int64)
+ */
+async function getPendingChannelCapacities () {
+  const { pendingOpenChannels = [] } = await listPendingChannels({ client: this.client })
+
+  if (pendingOpenChannels.length === 0) {
+    this.logger.debug('getPendingChannelCapacities: No channels exist')
+    return { localBalance: Big(0).toString(), remoteBalance: Big(0).toString() }
+  }
+
+  const totalLocalBalance = pendingOpenChannels.reduce((acc, c) => {
+    return acc.plus(c.channel.localBalance)
+  }, Big(0))
+
+  const totalRemoteBalance = pendingOpenChannels.reduce((acc, c) => {
+    return acc.plus(c.channel.remoteBalance)
+  }, Big(0))
+
+  return { localBalance: totalLocalBalance.toString(), remoteBalance: totalRemoteBalance.toString() }
+}
+
+module.exports = getPendingChannelCapacities

--- a/src/engine-actions/get-pending-channel-capacities.js
+++ b/src/engine-actions/get-pending-channel-capacities.js
@@ -11,7 +11,6 @@ async function getPendingChannelCapacities () {
 
   if (pendingOpenChannels.length === 0) {
     this.logger.debug('getPendingChannelCapacities: No channels exist')
-    return { localBalance: Big(0).toString(), remoteBalance: Big(0).toString() }
   }
 
   const totalLocalBalance = pendingOpenChannels.reduce((acc, c) => {

--- a/src/engine-actions/get-pending-channel-capacities.spec.js
+++ b/src/engine-actions/get-pending-channel-capacities.spec.js
@@ -1,0 +1,37 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const getPendingChannelCapacities = rewire(path.resolve(__dirname, 'get-pending-channel-capacities'))
+
+describe('getPendingChannelCapacities', () => {
+  let pendingOpenChannels
+  let listChannelsStub
+  let logger
+
+  beforeEach(() => {
+    pendingOpenChannels = [
+      { channel: { localBalance: '10', remoteBalance: '300' } },
+      { channel: { localBalance: '0', remoteBalance: '100' } }
+    ]
+
+    logger = {
+      debug: sinon.stub()
+    }
+
+    getPendingChannelCapacities.__set__('logger', logger)
+  })
+
+  it('returns 0 for active and inactive if no channels exist', async () => {
+    const expectedRes = { localBalance: '0', remoteBalance: '0' }
+    listChannelsStub = sinon.stub().resolves({})
+    getPendingChannelCapacities.__set__('listPendingChannels', listChannelsStub)
+    return expect(await getPendingChannelCapacities()).to.eql(expectedRes)
+  })
+
+  it('returns the total balance of all channels on a daemon', async () => {
+    const expectedRes = { localBalance: '10', remoteBalance: '400' }
+    listChannelsStub = sinon.stub().resolves({ pendingOpenChannels })
+    getPendingChannelCapacities.__set__('listPendingChannels', listChannelsStub)
+    return expect(await getPendingChannelCapacities()).to.eql(expectedRes)
+  })
+})

--- a/src/engine-actions/index.js
+++ b/src/engine-actions/index.js
@@ -23,6 +23,8 @@ const getSettledSwapPreimage = require('./get-settled-swap-preimage')
 const numChannelsForAddress = require('./num-channels-for-address')
 const getTotalPendingChannelBalance = require('./get-total-pending-channel-balance')
 const getUncommittedPendingBalance = require('./get-uncommitted-pending-balance')
+const getPendingChannelCapacities = require('./get-pending-channel-capacities')
+const getOpenChannelCapacities = require('./get-open-channel-capacities')
 
 module.exports = {
   getInvoices,
@@ -49,5 +51,7 @@ module.exports = {
   getSettledSwapPreimage,
   numChannelsForAddress,
   getTotalPendingChannelBalance,
-  getUncommittedPendingBalance
+  getUncommittedPendingBalance,
+  getPendingChannelCapacities,
+  getOpenChannelCapacities
 }


### PR DESCRIPTION
We need the local and remote trading capacities for all active, pending and inactive channels in order to create the trading statuses table for the CLI. 