### PR TITLE
remove experimental tag for bitcoind/litecoind

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The following repo contains 2 modules that make up a SparkSwap Payment Channel N
 2. Dockerfiles for all containers needed for the LND Engine to run on a broker daemon
 
 A current docker setup a functional BTC/LTC LND Engine:
-1. Bitcoin node (BTCD is default)
+1. Bitcoin node (currently bitcoind)
 2. LND BTC node (SparkSwap fork)
-3. Litecoin node (LTCD is default)
+3. Litecoin node (currently litecoind)
 4. LND LTC node (SparkSwap fork)
 
 #### Installation (lnd-engine only)
@@ -23,12 +23,6 @@ the lnd-engine codebase and will build all docker images
 
 ```
 npm run build
-```
-
-You can prevent the building of docker images with:
-
-```
-npm run build no-docker
 ```
 
 Additionally, You can then use `npm run build-images` to build docker images separately.
@@ -58,7 +52,7 @@ engine.getUncommittedBalance.... etc
 
 # API
 
-Documentation is up-to-date as of 119fcabe94d286c88a144d9c3de1f78e85fc64ed
+Documentation is up-to-date as of v0.2.0-alpha-release
 
 **NOTE:** Please see detailed documentation at [sparkswap.com/docs/engines/lnd](https://sparkswap.com/docs/engines/lnd)
 

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -15,12 +15,12 @@ LND_VERSION='k#epic/cross-chain-preimage'
 # to cache old code and we would never receive updates from the fork.
 COMMIT_SHA=`git ls-remote git://github.com/sparkswap/lnd | grep "refs/heads/$LND_VERSION$" | cut -f 1`
 
-if [[ "$ARG" == "experimental" ]]; then
-  LND_BTC_NODE=bitcoind
-  LND_LTC_NODE=litecoind
-else
+if [[ "$ARG" == "local" ]]; then
   LND_BTC_NODE=btcd
   LND_LTC_NODE=ltcd
+else
+  LND_BTC_NODE=bitcoind
+  LND_LTC_NODE=litecoind
 fi
 
 # NOTE: The names specified with `-t` directly map to the service names in
@@ -37,18 +37,9 @@ if [[ "$ARG" == "local" ]]; then
   BTCD_COMMIT_SHA=`git ls-remote git://github.com/btcsuite/btcd | grep "refs/heads/$BTCD_VERSION$" | cut -f 1`
   docker build -t sparkswap_btcd ./docker/btcd --build-arg COMMIT_SHA=$BTCD_COMMIT_SHA --build-arg CERT_HOST=$BTCD_CERT_HOST
   docker build -t sparkswap_ltcd ./docker/ltcd --build-arg COMMIT_SHA=$LTCD_COMMIT_SHA --build-arg CERT_HOST=$LTCD_CERT_HOST
-elif [[ "$ARG" == "experimental" ]]; then
+else
   BITCOIND_VERSION='0.17.0'
   docker build -t sparkswap_bitcoind ./docker/bitcoind --build-arg VERSION=$BITCOIND_VERSION
   LITECOIND_VERSION='0.16.3'
   docker build -t sparkswap_litecoind ./docker/litecoind --build-arg VERSION=$LITECOIND_VERSION
-else
-  LTCD_CERT_HOST=${LTCD_CERT_HOST:-ltcd}
-  BTCD_CERT_HOST=${BTCD_CERT_HOST:-btcd}
-  LTCD_VERSION='master'
-  BTCD_VERSION='master'
-  LTCD_COMMIT_SHA=`git ls-remote git://github.com/ltcsuite/ltcd | grep "refs/heads/$LTCD_VERSION$" | cut -f 1`
-  BTCD_COMMIT_SHA=`git ls-remote git://github.com/btcsuite/btcd | grep "refs/heads/$BTCD_VERSION$" | cut -f 1`
-  docker build -t sparkswap_btcd ./docker/btcd --build-arg COMMIT_SHA=$BTCD_COMMIT_SHA --build-arg CERT_HOST=$BTCD_CERT_HOST
-  docker build -t sparkswap_ltcd ./docker/ltcd --build-arg COMMIT_SHA=$LTCD_COMMIT_SHA --build-arg CERT_HOST=$LTCD_CERT_HOST
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,12 +32,9 @@ sed 's|^import \"google/api/annotations.proto\";||' ./proto/lnd-rpc.proto > /tmp
 
 # If we want to build images with the command then we can use
 if [ "$ARG" == "local" ]; then
-  echo "building local broker docker images"
+  echo "Building local broker docker images"
   npm run build-images local
-elif [ "$ARG" == "experimental" ]; then
-  echo "building broker docker images"
-  npm run build-images experimental
-elif [ "$ARG" != "no-docker" ]; then
-  echo "building broker docker images"
+else
+  echo "Building broker docker images"
   npm run build-images
 fi


### PR DESCRIPTION
This PR is the final change to have bitcoind/litecoind as the default daemons for the lnd-engine.

LND engine will now have the following build commands:
```
npm run build local // development only
npm run build
```