### PR TITLE
Fix - successful validation after validation retries

### DIFF
--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -1,3 +1,5 @@
+const grpc = require('grpc')
+
 const { genSeed } = require('../lnd-actions')
 const isAvailable = require('./is-available')
 
@@ -9,7 +11,7 @@ const isAvailable = require('./is-available')
  * @type {Number}
  * @default
  */
-const UNIMPLEMENTED_SERVICE_CODE = 12
+const UNIMPLEMENTED_SERVICE_CODE = grpc.status.UNIMPLEMENTED
 
 /**
  * @constant

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -43,7 +43,7 @@ async function isEngineUnlocked () {
     // WalletUnlocker RPC has never been started and the Lightning RPC is functional
     //
     // This state happens when an engine is being used in development mode (noseedbackup)
-    if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
+    if (e.code === UNIMPLEMENTED_SERVICE_CODE) {
       return true
     }
 
@@ -74,7 +74,7 @@ async function isEngineUnlocked () {
       } catch (e) {
         // If a 'wallet already exists', but lnrpc (Lighting RPC) is not implemented
         // then the engine is still locked and the user needs to unlock the wallet
-        if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
+        if (e.code === UNIMPLEMENTED_SERVICE_CODE) {
           return false
         }
       }

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -65,7 +65,7 @@ async function isEngineUnlocked () {
     //
     // Unfortunately, we have to string match on the error since the error code
     // returned is generic (code 2)
-    if (e.message.includes(WALLET_EXISTS_ERROR_MESSAGE)) {
+    if (e.message && e.message.includes(WALLET_EXISTS_ERROR_MESSAGE)) {
       // At this point, `genSeed` has returns a `wallet already exists` error message
       // however we still don't know if the engine is locked or unlocked because this
       // error message is returned for any state.

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -43,30 +43,30 @@ async function isEngineUnlocked () {
     // supported/enabled in this specific service. In our case, this means the
     // WalletUnlocker RPC has never been started and the Lightning RPC is functional
     //
-    // This state typically happens when a wallet doesn't exist OR the engine is
-    // being used in development mode (noseedbackup)
+    // This state happens when an engine is being used in development mode (noseedbackup)
     if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
       return true
     }
 
-    // If we receive an `wallet already exists` error, than two things may be happening:
+    // If we receive an `wallet already exists` error, then one of two things
+    // may be happening:
     //
-    // 1. the consumer just restarted there node and the engine is now re-locked
-    // 2. The consumer has just successfully unlocked their engine but we are waiting
+    // 1. the consumer just restarted their nodes and the engine is now locked
+    // 2. The consumer has successfully unlocked their engine but we are waiting
     //    for re-validation
     //
     // In the first case (#1), if we receive an `wallet already exists` error AND
-    // the lightning RPC is not implemented, than we can safetly say that the engine
-    // is locked.
+    // lnrpc (Lightning RPC) is not implemented, we can safely assume that the engine
+    // is still locked.
     //
-    // However, if the error exists AND the RPC is available, then we can determine
-    // that the engine is unlocked and we can proceed to the next step.
+    // However, if the error exists AND lnrpc (Lightning RPC) is available, we can
+    // assume that the engine is unlocked
     //
-    // We must identify these cases because 'genSeeds' will return `wallet already exists`
-    // for any state on the engine outside of development mode (noseedbackup)
+    // The issue lies in 'genSeeds', which will return `wallet already exists` for
+    // any state (locked or unlocked) on the engine.
     //
-    // Unfortunately we have to string match on the error, since the error code returned
-    // is generic (code 2)
+    // Unfortunately, we have to string match on the error since the error code
+    // returned is generic (code 2)
     if (e.message && e.message.includes(WALLET_EXISTS_ERROR_MESSAGE)) {
       // At this point, `genSeed` has returns a `wallet already exists` error message
       // however we still don't know if the engine is locked or unlocked because this

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -61,7 +61,6 @@ async function isEngineUnlocked () {
       try {
         await isAvailable.call(this)
       } catch (e) {
-        console.log(e)
         if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
           return false
         }

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -1,6 +1,5 @@
-const {
-  genSeed
-} = require('../lnd-actions')
+const { genSeed } = require('../lnd-actions')
+const isAvailable = require('./is-available')
 
 /**
  * CODE 12 for gRPC is equal to 'unimplemented'
@@ -57,6 +56,16 @@ async function isEngineUnlocked () {
     // Unfortunately we have to string match on the error, since the error code returned
     // is generic (code 2)
     if (e.message && e.message.includes(WALLET_EXISTS_ERROR_MESSAGE)) {
+      // At this point, genSeed is up and a wallet exists on the server, however
+      // we need to make sure that this isn't because of
+      try {
+        await isAvailable.call(this)
+      } catch (e) {
+        if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
+          return false
+        }
+      }
+
       return true
     }
 

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -65,7 +65,7 @@ async function isEngineUnlocked () {
     //
     // Unfortunately, we have to string match on the error since the error code
     // returned is generic (code 2)
-    if (e.message && e.message.includes(WALLET_EXISTS_ERROR_MESSAGE)) {
+    if (e.message.includes(WALLET_EXISTS_ERROR_MESSAGE)) {
       // At this point, `genSeed` has returns a `wallet already exists` error message
       // however we still don't know if the engine is locked or unlocked because this
       // error message is returned for any state.

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -61,10 +61,10 @@ async function isEngineUnlocked () {
       try {
         await isAvailable.call(this)
       } catch (e) {
+        console.log(e)
         if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
           return false
         }
-        throw e
       }
 
       return true

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -13,6 +13,13 @@ const {
 const UNIMPLEMENTED_SERVICE_CODE = 12
 
 /**
+ * @constant
+ * @type {String}
+ * @default
+ */
+const WALLET_EXISTS_ERROR_MESSAGE = 'wallet already exists'
+
+/**
  * Rough estimate if the engine's node unlocked or not. Sets the `unlocked` flag
  * on an engine.
  *
@@ -33,6 +40,16 @@ async function isEngineUnlocked () {
     // supported/enabled in this specific service. In our case, this means the
     // WalletUnlocker RPC has been turned off and the Lightning RPC is now functional
     if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
+      return true
+    }
+
+    // If an error has been received that states a wallet exists, then this means that
+    // either the user has just created a wallet (and we are revalidating the engine) or
+    // the user has just unlocked the engine successfully.
+    //
+    // Unfortunately we have to string match on the error, since the error code returned
+    // is generic (code 2)
+    if (e.message && e.message.includes(WALLET_EXISTS_ERROR_MESSAGE)) {
       return true
     }
 

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -64,6 +64,7 @@ async function isEngineUnlocked () {
         if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
           return false
         }
+        throw e
       }
 
       return true

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -74,6 +74,8 @@ async function isEngineUnlocked () {
       try {
         await isAvailable.call(this)
       } catch (e) {
+        // If a 'wallet already exists', but lnrpc (Lighting RPC) is not implemented
+        // then the engine is still locked and the user needs to unlock the wallet
         if (e.code && e.code === UNIMPLEMENTED_SERVICE_CODE) {
           return false
         }

--- a/src/engine-actions/is-engine-unlocked.js
+++ b/src/engine-actions/is-engine-unlocked.js
@@ -31,11 +31,10 @@ const WALLET_EXISTS_ERROR_MESSAGE = 'wallet already exists'
  */
 async function isEngineUnlocked () {
   try {
-    // If the call to `genSeed` succeeds, then there are two possible states that
-    // the engine could be in:
-    //
+    // If the call to `genSeed` succeeds, there will be two possible states that
+    // an engine could be in:
     // 1. The engine is locked and the user needs to either create a wallet or unlock the wallet
-    // 2. The engine has been unlocked during exponential backoff, in which case
+    // 2. The engine has been unlocked during an exponential backoff, in which case
     //    the WalletUnlocked RPC is still available
     await genSeed({ client: this.walletUnlocker })
   } catch (e) {
@@ -48,22 +47,21 @@ async function isEngineUnlocked () {
       return true
     }
 
-    // If we receive an `wallet already exists` error, then one of two things
+    // The call to 'genSeeds', which will return `wallet already exists` for
+    // any state (locked or unlocked) on the engine.
+    //
+    // If we receive a `wallet already exists` error, then one of two things
     // may be happening:
     //
-    // 1. the consumer just restarted their nodes and the engine is now locked
-    // 2. The consumer has successfully unlocked their engine but we are waiting
-    //    for re-validation
+    // 1. The user just restarted their node and the engine is now locked
+    // 2. The user has successfully unlocked their engine but are waiting
+    //    for re-validation of the engine
     //
-    // In the first case (#1), if we receive an `wallet already exists` error AND
-    // lnrpc (Lightning RPC) is not implemented, we can safely assume that the engine
-    // is still locked.
+    // In the first case (#1), if we receive `wallet already exists` AND lnrpc (Lightning RPC)
+    // is not implemented, we can safely assume that the engine is still locked.
     //
-    // However, if the error exists AND lnrpc (Lightning RPC) is available, we can
-    // assume that the engine is unlocked
-    //
-    // The issue lies in 'genSeeds', which will return `wallet already exists` for
-    // any state (locked or unlocked) on the engine.
+    // If the error exists AND lnrpc (Lightning RPC) is available, we can assume
+    // that the engine is unlocked
     //
     // Unfortunately, we have to string match on the error since the error code
     // returned is generic (code 2)

--- a/src/engine-actions/is-engine-unlocked.spec.js
+++ b/src/engine-actions/is-engine-unlocked.spec.js
@@ -6,14 +6,17 @@ const isEngineUnlocked = rewire(path.resolve(__dirname, 'is-engine-unlocked'))
 describe('isEngineUnlocked', () => {
   let engine
   let genSeedStub
+  let isAvailableStub
 
   beforeEach(() => {
     engine = {
       walletUnlocker: sinon.stub()
     }
     genSeedStub = sinon.stub()
+    isAvailableStub = sinon.stub().resolves(true)
 
     isEngineUnlocked.__set__('genSeed', genSeedStub)
+    isEngineUnlocked.__set__('isAvailable', isAvailableStub)
   })
 
   it('makes a call to genSeed to see if lnd is unlocked', async () => {
@@ -27,20 +30,35 @@ describe('isEngineUnlocked', () => {
     expect(isEngineUnlocked.call(engine)).to.eventually.be.rejectedWith(error)
   })
 
-  context('wallet is unlocked', () => {
-    it('returns true if genSeeds is not implemented', async () => {
-      const error = new Error()
-      error.code = 12
-      genSeedStub.throws(error)
-      const res = await isEngineUnlocked.call(engine)
-      expect(res).to.be.eql(true)
-    })
+  it('returns true if genSeeds is not implemented', async () => {
+    const error = new Error()
+    error.code = 12
+    genSeedStub.throws(error)
+    const res = await isEngineUnlocked.call(engine)
+    expect(res).to.be.eql(true)
+  })
 
-    it('returns true if a wallet already exists', async () => {
-      const error = new Error('wallet already exists')
-      genSeedStub.throws(error)
-      const res = await isEngineUnlocked.call(engine)
-      expect(res).to.be.eql(true)
-    })
+  it('returns true if a wallet already exists', async () => {
+    const error = new Error('wallet already exists')
+    genSeedStub.throws(error)
+    const res = await isEngineUnlocked.call(engine)
+    expect(res).to.be.eql(true)
+  })
+
+  it('returns false if a wallet already exists but the wallet is still locked', async () => {
+    const error = new Error('wallet already exists')
+    genSeedStub.throws(error)
+    const lnError = new Error('Unimplemented')
+    lnError.code = 12
+    isAvailableStub.throws(lnError)
+    const res = await isEngineUnlocked.call(engine)
+    expect(res).to.be.eql(false)
+  })
+
+  it('returns true if a wallet already exists and the engine is available', async () => {
+    const error = new Error('wallet already exists')
+    genSeedStub.throws(error)
+    const res = await isEngineUnlocked.call(engine)
+    expect(res).to.be.eql(true)
   })
 })

--- a/src/engine-actions/is-engine-unlocked.spec.js
+++ b/src/engine-actions/is-engine-unlocked.spec.js
@@ -21,26 +21,25 @@ describe('isEngineUnlocked', () => {
     expect(genSeedStub).to.have.been.calledWith(sinon.match({ client: engine.walletUnlocker }))
   })
 
-  it('throws an error if the call to genSeed fails, but is implemented', async () => {
+  it('throws an error if the call to genSeed fails unexpectedly', async () => {
     const error = 'bad request'
     genSeedStub.throws(new Error(error))
     expect(isEngineUnlocked.call(engine)).to.eventually.be.rejectedWith(error)
   })
 
   context('wallet is unlocked', () => {
-    let res
-
-    beforeEach(() => {
+    it('returns true if genSeeds is not implemented', async () => {
       const error = new Error()
       error.code = 12
       genSeedStub.throws(error)
+      const res = await isEngineUnlocked.call(engine)
+      expect(res).to.be.eql(true)
     })
 
-    beforeEach(async () => {
-      res = await isEngineUnlocked.call(engine)
-    })
-
-    it('returns true if an engine is unlocked', () => {
+    it('returns true if a wallet already exists', async () => {
+      const error = new Error('wallet already exists')
+      genSeedStub.throws(error)
+      const res = await isEngineUnlocked.call(engine)
       expect(res).to.be.eql(true)
     })
   })

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,6 @@ class LndEngine {
         //
         // We regenerate the 'client' here in-case macaroons did not exist during the
         // creation of a new LndEngine.
-        // TODO: Should we only generate the client here?
         this.client = generateLightningClient(this)
 
         // An Engine is `locked` when no wallet is present OR if LND Engine requires

--- a/src/index.js
+++ b/src/index.js
@@ -106,8 +106,12 @@ class LndEngine {
           throw new Error('LndEngine is locked, unable to validate config')
         }
 
-        // Regenerate lightning client just in-case we went through setup and the
-        // macaroons didn't exist for lnd (this happens when an engine was previously locked)
+        // A macaroon file for lnd will only exist if the Lightning RPC has been started
+        // which means that the engine needs to be unlocked before this file is available.
+        //
+        // We regenerate the 'client' here in-case macaroons did not exist during the
+        // creation of a new LndEngine.
+        // TODO: Should we only generate the client here?
         this.client = generateLightningClient(this)
 
         // Once the engine is unlocked, we will attempt to validate our engine's

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,10 @@ class LndEngine {
           throw new Error('LndEngine is locked, unable to validate config')
         }
 
+        // Regenerate lightning client just in-case we went through setup and the
+        // macaroons didn't exist for lnd (this happens when an engine was previously locked)
+        this.client = generateLightningClient(this)
+
         // Once the engine is unlocked, we will attempt to validate our engine's
         // configuration. If we call `isNodeConfigValid` before the engine is unlocked
         // the call will fail without a friendly error

--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,14 @@ class LndEngine {
       const payload = { symbol: this.symbol }
       const errorMessage = 'Engine failed to validate. Retrying'
       const validationCall = async () => {
+        // A macaroon file for lnd will only exist if the Lightning RPC has been started
+        // which means that the engine needs to be unlocked before this file is available.
+        //
+        // We regenerate the 'client' here in-case macaroons did not exist during the
+        // creation of a new LndEngine.
+        // TODO: Should we only generate the client here?
+        this.client = generateLightningClient(this)
+
         // An Engine is `locked` when no wallet is present OR if LND Engine requires
         // a password to unlock the current wallet
         //
@@ -105,14 +113,6 @@ class LndEngine {
         if (!this.unlocked) {
           throw new Error('LndEngine is locked, unable to validate config')
         }
-
-        // A macaroon file for lnd will only exist if the Lightning RPC has been started
-        // which means that the engine needs to be unlocked before this file is available.
-        //
-        // We regenerate the 'client' here in-case macaroons did not exist during the
-        // creation of a new LndEngine.
-        // TODO: Should we only generate the client here?
-        this.client = generateLightningClient(this)
 
         // Once the engine is unlocked, we will attempt to validate our engine's
         // configuration. If we call `isNodeConfigValid` before the engine is unlocked

--- a/src/index.js
+++ b/src/index.js
@@ -95,11 +95,10 @@ class LndEngine {
       const payload = { symbol: this.symbol }
       const errorMessage = 'Engine failed to validate. Retrying'
       const validationCall = async () => {
-        // A macaroon file for lnd will only exist if the Lightning RPC has been started
-        // which means that the engine needs to be unlocked before this file is available.
-        //
-        // We regenerate the 'client' here in-case macaroons did not exist during the
-        // creation of a new LndEngine.
+        // A macaroon file for lnd will only exist if lnrpc (Lightning RPC) has been started
+        // on LND. Since an engine can become unlocked during any validation call, we
+        // need to ensure that we are updating LndEngine's client in the situation that
+        // a macaroon file becomes available (meaning an engine has been unlocked).
         this.client = generateLightningClient(this)
 
         // An Engine is `locked` when no wallet is present OR if LND Engine requires

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -105,15 +105,20 @@ describe('lnd-engine index', () => {
     let engine
     let exponentialStub
     let logger
+    let clientStub
+    let lndClient
 
     beforeEach(() => {
       exponentialStub = sinon.stub()
+      lndClient = sinon.stub()
+      clientStub = sinon.stub().returns(lndClient)
       logger = {
         info: sinon.stub(),
         error: sinon.stub()
       }
 
       LndEngine.__set__('exponentialBackoff', exponentialStub)
+      LndEngine.__set__('generateLightningClient', clientStub)
 
       engine = new LndEngine(host, symbol, { logger, tlsCertPath: customTlsCertPath, macaroonPath: customMacaroonPath, validations: false })
     })
@@ -154,6 +159,12 @@ describe('lnd-engine index', () => {
       it('sets unlocked property on the class to true if unlocked', async () => {
         await validationCall()
         expect(engine.unlocked).to.be.eql(true)
+      })
+
+      it('regenerates an lnd client after an engine has been unlocked', async () => {
+        await validationCall()
+        expect(engine.client).to.be.eql(lndClient)
+        expect(clientStub).to.have.been.calledTwice()
       })
 
       it('sets validated property on the class to true if validated', async () => {

--- a/src/utils/exponential-backoff.js
+++ b/src/utils/exponential-backoff.js
@@ -48,10 +48,8 @@ async function exponentialBackoff (callFunction, payload = {}, { errorMessage = 
       const nextDelayTime = delayTime * DELAY_MULTIPLIER
 
       if (errorMessage) {
-        logger.debug(errorMessage, { payload, delayTime, attemptsLeft, error: error.message, stack: error.stack })
         logger.error(errorMessage, { payload, delayTime, attemptsLeft, error: error.message })
       } else {
-        logger.error(`Error calling ${callFunction}. Retrying in ${Math.round(delayTime / 1000)} seconds, attempts left: ${attemptsLeft}`, { payload, error: error.message, stack: error.stack })
         logger.error(`Error calling ${callFunction}. Retrying in ${Math.round(delayTime / 1000)} seconds, attempts left: ${attemptsLeft}`, { payload, error: error.message })
       }
 

--- a/src/utils/exponential-backoff.js
+++ b/src/utils/exponential-backoff.js
@@ -48,9 +48,11 @@ async function exponentialBackoff (callFunction, payload = {}, { errorMessage = 
       const nextDelayTime = delayTime * DELAY_MULTIPLIER
 
       if (errorMessage) {
-        logger.error(errorMessage, { payload, delayTime, attemptsLeft, error })
+        logger.debug(errorMessage, { payload, delayTime, attemptsLeft, error: error.message, stack: error.stack })
+        logger.error(errorMessage, { payload, delayTime, attemptsLeft, error: error.message })
       } else {
-        logger.error(`Error calling ${callFunction}. Retrying in ${Math.round(delayTime / 1000)} seconds, attempts left: ${attemptsLeft}`, { payload, error })
+        logger.error(`Error calling ${callFunction}. Retrying in ${Math.round(delayTime / 1000)} seconds, attempts left: ${attemptsLeft}`, { payload, error: error.message, stack: error.stack })
+        logger.error(`Error calling ${callFunction}. Retrying in ${Math.round(delayTime / 1000)} seconds, attempts left: ${attemptsLeft}`, { payload, error: error.message })
       }
 
       await delay(delayTime)


### PR DESCRIPTION
Stick with me cause this is going to be a long one.

In order to identify if an LND instance (engine) is in a certain state, we use the `genSeed` method. (simply cause there is no identifier on lnd to let us know what kind of state its in).

This poses issues where LND may or may not have access to `genSeed` and may or may not have access to a macaroon file.

This PR contains changes to `isEngineUnlocked` and `validateNodeConfig` code that allows validation to occur, as expected, in the following circumstances:

1. An engine is locked when a wallet needs to be created
2. An engine is locked when a wallet is available, but needs a password to be unlocked
3. An engine is unlocked when a wallet was created AFTER validation had failed
4. An engine is unlocked when a wallet is available AFTER validation had failed

This PR resolves #3 and #4, where the engine would act like it was in a `locked` even after commands had been made to unlock a wallet successfully. Once the lnrpc activates on lnd, it creates a macaroon, but we never regenerate `this.client` which causes failures until the broker is restarted (through docker)