### PR TITLE
make EXTERNAL_ADDRESS optional for lnd setup

### DIFF
--- a/docker/lnd/start-lnd-btc.sh
+++ b/docker/lnd/start-lnd-btc.sh
@@ -5,20 +5,12 @@ set -e
 NODE=${NODE:-bitcoind}
 CONFIG_FILE=/home/lnd/lnd.conf
 
-# Simple check to make sure that the user has changed the external url of lnd_btc
-# outside of regtest. This will cause unintended issues w/ routing through the relayer
-if [[ "$NETWORK" != 'regtest' ]] && [[ "$EXTERNAL_ADDRESS" == *"sample.ip.address"* ]]; then
-    echo "Your current external address for LND_BTC is set to an internal address. Please change this for $NETWORK"
-    exit 1
-fi
-
 echo "LND BTC starting with network: $NETWORK $NODE"
 
 PARAMS=$(echo \
     "--configfile=$CONFIG_FILE" \
     "--bitcoin.$NETWORK" \
     "--debuglevel=$DEBUG" \
-    "--externalip=$EXTERNAL_ADDRESS" \
     "--extpreimage.rpchost=$EXTPREIMAGE_HOST" \
     "--$NODE.rpcuser=$RPC_USER" \
     "--$NODE.rpcpass=$RPC_PASS" \
@@ -26,6 +18,11 @@ PARAMS=$(echo \
     "--$NODE.zmqpubrawblock=$ZMQPUBRAWBLOCK" \
     "--$NODE.zmqpubrawtx=$ZMQPUBRAWTX"
 )
+
+if [[ -n "$EXTERNAL_ADDRESS" ]]; then
+    echo "Setting external address for lnd $EXTERNAL_ADDRESS"
+    PARAMS="$PARAMS --externalip=$EXTERNAL_ADDRESS"
+fi
 
 if [[ -n "$LND_BASE_FEE" ]]; then
     echo "Setting custom base fee for bitcoin: $LND_BASE_FEE"

--- a/docker/lnd/start-lnd-ltc.sh
+++ b/docker/lnd/start-lnd-ltc.sh
@@ -5,20 +5,12 @@ set -e
 NODE=${NODE:-litecoind}
 CONFIG_FILE=/home/lnd/lnd.conf
 
-# Simple check to make sure that the user has changed the external url of lnd_btc
-# outside of regtest. This will cause unintended issues w/ routing through the relayer
-if [[ "$NETWORK" != 'regtest' ]] && [[ "$EXTERNAL_ADDRESS" == *"sample.ip.address"* ]]; then
-    echo "Your current external address for LND_LTC is set to an internal address. Please change this for $NETWORK"
-    exit 1
-fi
-
 echo "LND LTC starting with network: $NETWORK $NODE"
 
 PARAMS=$(echo \
     "--configfile=$CONFIG_FILE" \
     "--litecoin.$NETWORK" \
     "--debuglevel=$DEBUG" \
-    "--externalip=$EXTERNAL_ADDRESS" \
     "--extpreimage.rpchost=$EXTPREIMAGE_HOST" \
     "--$NODE.rpcuser=$RPC_USER" \
     "--$NODE.rpcpass=$RPC_PASS" \
@@ -26,6 +18,11 @@ PARAMS=$(echo \
     "--$NODE.zmqpubrawblock=$ZMQPUBRAWBLOCK" \
     "--$NODE.zmqpubrawtx=$ZMQPUBRAWTX"
 )
+
+if [[ -n "$EXTERNAL_ADDRESS" ]]; then
+    echo "Setting external address for lnd $EXTERNAL_ADDRESS"
+    PARAMS="$PARAMS --externalip=$EXTERNAL_ADDRESS"
+fi
 
 if [[ -n "$LND_BASE_FEE" ]]; then
     echo "Setting custom base fee for litecoin: $LND_BASE_FEE"


### PR DESCRIPTION
`EXTERNAL_ADDRESS` should be an optional property on our LND setup, as a static IP is not required to use the relayer/lightning network