### PR TITLE
Remove log messages for getting the balance with no channels

### DIFF
--- a/src/engine-actions/get-total-balance-for-address.js
+++ b/src/engine-actions/get-total-balance-for-address.js
@@ -11,11 +11,6 @@ const getChannelsForRemoteAddress = require('./get-channels-for-remote-address')
 async function getTotalBalanceForAddress (address, { outbound = true } = {}) {
   const channelsForAddress = await getChannelsForRemoteAddress.call(this, address)
 
-  if (channelsForAddress.length === 0) {
-    this.logger.debug('getTotalBalanceForAddress: No open or pending channels exist', { symbol: this.symbol, address })
-    return Big(0).toString()
-  }
-
   const balanceType = outbound ? 'localBalance' : 'remoteBalance'
   const totalBalance = channelsForAddress.reduce((acc, c) => {
     return acc.plus(c[balanceType])

--- a/src/engine-actions/get-total-balance-for-address.spec.js
+++ b/src/engine-actions/get-total-balance-for-address.spec.js
@@ -48,7 +48,6 @@ describe('getTotalBalanceForAddress', () => {
 
     const expectedRes = '0'
     const res = await getTotalBalanceForAddress(address)
-    expect(logger.debug).to.have.been.calledWith('getTotalBalanceForAddress: No open or pending channels exist')
     expect(res).to.eql(expectedRes)
   })
 

--- a/src/engine-actions/get-total-channel-balance.js
+++ b/src/engine-actions/get-total-channel-balance.js
@@ -9,11 +9,6 @@ const { listChannels } = require('../lnd-actions')
 async function getTotalChannelBalance () {
   const { channels = [] } = await listChannels({ client: this.client })
 
-  if (channels.length === 0) {
-    this.logger.debug('getTotalChannelBalance: No channels exist', { symbol: this.symbol })
-    return Big(0).toString()
-  }
-
   const totalLocalBalance = channels.reduce((acc, c) => {
     return acc.plus(c.localBalance)
   }, Big(0))

--- a/src/engine-actions/get-total-pending-channel-balance.js
+++ b/src/engine-actions/get-total-pending-channel-balance.js
@@ -9,11 +9,6 @@ const { listPendingChannels } = require('../lnd-actions')
 async function getTotalPendingChannelBalance () {
   const { pendingOpenChannels = [] } = await listPendingChannels({ client: this.client })
 
-  if (pendingOpenChannels.length === 0) {
-    this.logger.debug(`getTotalPendingChannelBalance: No channels exist`, { symbol: this.symbol })
-    return Big(0).toString()
-  }
-
   const totalPendingLocalBalance = pendingOpenChannels.reduce((acc, c) => {
     return acc.plus(c.channel.localBalance)
   }, Big(0))

--- a/src/engine-actions/get-total-reserved-channel-balance.js
+++ b/src/engine-actions/get-total-reserved-channel-balance.js
@@ -15,7 +15,6 @@ async function getTotalReservedChannelBalance () {
   // a channel are calculated less commit fees when a party was the initiator. The rationale of
   // this calculation is to put the responsibility on the initiator to pay for a force-close
   const initiatorChannels = channels.filter(c => c.initiator)
-  this.logger.debug(`getTotalReservedChannelBalance: ${channels.length} channels exist, ${initiatorChannels.length} channels as initiator`)
 
   const totalReservedChannelBalance = initiatorChannels.reduce((acc, c) => {
     return acc.plus(c.commitFee)

--- a/src/engine-actions/get-uncommitted-pending-balance.js
+++ b/src/engine-actions/get-uncommitted-pending-balance.js
@@ -9,11 +9,6 @@ async function getUncommittedPendingBalance () {
   const { unconfirmedBalance } = await walletBalance({ client: this.client })
   const { pendingForceClosingChannels = [] } = await listPendingChannels({ client: this.client })
 
-  if (!pendingForceClosingChannels.length) {
-    this.logger.debug('getUncommittedPendingBalance: No pendingForceClosingChannels exist', { symbol: this.symbol })
-    return Big(unconfirmedBalance).toString()
-  }
-
   /**
    * When closing a channel, we were getting a duplicated pending unconfirmed balance.
    * This is because unconfirmedBalance for the wallet and waitingCloseChannels from listChannels contain the same information.


### PR DESCRIPTION
These messages add a lot of clutter to the logs and don't provide much value.