### PR TITLE
fix eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2127,7 +2127,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -2587,9 +2587,9 @@
       }
     },
     "handlebars": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.3.tgz",
-      "integrity": "sha512-VupOxR91xcGojfINrzMqrvlyYbBs39sXIrWa7YdaQWeBudOlvKEGvCczMfJPgnuwHE/zyH1M6J+IUP6cgDVyxg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4514,7 +4514,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -5300,16 +5300,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
+      "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/src/constants/channel-rounding.js
+++ b/src/constants/channel-rounding.js
@@ -1,12 +1,10 @@
 
-/** @typedef {{[k: string]: string}} Dictionary */
-
 /**
  * List of rounding behaviors when opening multiple channels and encountering a channel that
  * would be uneconomically small.
  *
  * @constant
- * @type {Dictionary}
+ * @type {object}
  * @default
  */
 const CHANNEL_ROUNDING = Object.freeze({

--- a/src/constants/engine-statuses.js
+++ b/src/constants/engine-statuses.js
@@ -1,12 +1,10 @@
 
-/** @typedef {{[k: string]: string}} Dictionary */
-
 /**
  * List of statuses for an lnd-engine. Each status represents a step in an engine's
  * lifecycle
  *
  * @constant
- * @type {Dictionary}
+ * @type {object}
  * @default
  */
 const ENGINE_STATUSES = Object.freeze({


### PR DESCRIPTION
We bumped eslint and started receiving linting errors because the typedefs are no longer supported 
 `2:0  warning  Syntax error in type: {[k: string]: string}  jsdoc/valid-types` This PR changes these to `object`